### PR TITLE
config: fix bootstrap 3.2.0 version

### DIFF
--- a/config/_config.yml
+++ b/config/_config.yml
@@ -71,7 +71,7 @@ bootswatch:
 # TODO: Perhaps move to a database (redis or mongo),
 # or to its own configuration file.
 bootstrap:
-    - version: "3.1.1"
+    - version: "3.2.0"
       latest: true
       css_complete: "//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css"
       javascript:  "//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"


### PR DESCRIPTION
@jdorfman forgot to adjust the version when he added 3.2.0 to the config, which is apparent when one goes to www.bootstrapcdn.com (unless of course that hasn't been updated yet).

For those interested in what may have caused this to slip past, take a read of [The Last Line Effect](http://www.viva64.com/en/b/0260/print/).
