### PR TITLE
Don't use a hardcoded core number.

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,15 @@ var os = require('os');
 /**
  * Setup
  **/
-var numOfCores = os.cpus().length / 2;
+var env = process.env.NODE_ENV;
+var cores = os.cpus().length;
+var numOfCores;
+if (env === "production") {
+    numOfCores = cores === 1 ? cores : cores - 1;
+} else {
+    numOfCores = cores > 1 ? cores / 2 : cores;
+}
+
 var workers = parseInt(process.env.CLUSTER_WORKERS || numOfCores, 10);
 
 cluster.setupMaster({ exec : "app.js" });
@@ -39,7 +47,7 @@ setInterval(checkRestart, 2000);
 say("Master starting:");
 say("time        => " + datefmt(new Date(), "ddd, dd mmm yyyy hh:MM:ss Z"));
 say("pid         => " + process.pid);
-say("environment => " + process.env.NODE_ENV);
+say("environment => " + env);
 
 /**
  * Fork Workers


### PR DESCRIPTION
Instead use `number_of_cores / 2`.

I used this since the previous was `2` too so on my 4 core machine I get 2.
