### PR TITLE
Don't hardcode `bootstrap.min.js`'s version.

### DIFF
--- a/config/_config.yml
+++ b/config/_config.yml
@@ -35,7 +35,7 @@ javascript:
     # as blocking scripts at the bottom of the page
     after:
     - "//code.jquery.com/jquery-1.11.1.min.js"
-    - "//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js"
+    - "//maxcdn.bootstrapcdn.com/bootstrap/SWATCH_VERSION/js/bootstrap.min.js"
 
 ####
 # TODO: Perhaps move to a database (redis or mongo),

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -34,6 +34,7 @@ html(lang="en")
 
         - if (config.javascript && config.javascript.after)
             - each js in config.javascript.after
+                - js=js.replace('SWATCH_VERSION', config.bootswatch.version)
                 script(src=js)
         - if (config.google_analytics)
             include _partials/javascripts/google_analytics


### PR DESCRIPTION
Fixes #437.
