### PR TITLE
Update xo and fix rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "pug-lint": "^2.6.0",
                 "pug-lint-config-clock": "^2.0.0",
                 "request": "^2.88.2",
-                "xo": "^0.38.2"
+                "xo": "^0.39.1"
             },
             "engines": {
                 "node": "14.x"
@@ -3323,9 +3323,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
-            "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+            "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -3335,9 +3335,9 @@
             }
         },
         "node_modules/eslint-config-xo": {
-            "version": "0.35.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.35.0.tgz",
-            "integrity": "sha512-+WyZTLWUJlvExFrBU/Ldw8AB/S0d3x+26JQdBWbcqig2ZaWh0zinYcHok+ET4IoPaEcRRf3FE9kjItNVjBwnAg==",
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.36.0.tgz",
+            "integrity": "sha512-RCaqCyI38awe3qgiO0Z8CqHs9yw7dMKdV6ZRTFSR7lm0//370tbDEZaQBXnztgpwe5m6D+VvFWc3vLMP/W6EAg==",
             "dev": true,
             "dependencies": {
                 "confusing-browser-globals": "1.0.10"
@@ -3353,9 +3353,9 @@
             }
         },
         "node_modules/eslint-config-xo-typescript": {
-            "version": "0.38.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.38.0.tgz",
-            "integrity": "sha512-f5z0gN1r9X84PK1qav6T6YT1zW6KcAqtsMPtmqoKBLt4ACRr6tbAddtFwqkluAEH9JvHjWxuB8vu4KJFcjuzdQ==",
+            "version": "0.39.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.39.0.tgz",
+            "integrity": "sha512-UP4WqkmAKerYAhJTLdfrjBhD/nM1ePEugQNBJjzFfZv/lJ4yQjTzDBjfjsgluX1kz9PajRMaaipiWloJEODdGg==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -3364,7 +3364,7 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             },
             "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": ">=4.14.0",
+                "@typescript-eslint/eslint-plugin": ">=4.21.0",
                 "eslint": ">=7.8.0",
                 "typescript": ">=3.6.0"
             }
@@ -3549,26 +3549,38 @@
             }
         },
         "node_modules/eslint-plugin-ava": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-11.0.0.tgz",
-            "integrity": "sha512-UMGedfl/gIKx1tzjGtAsTSJgowyAEZU2VWmpoWXYcuuV4B2H4Cu90yuMgMPEVt1mQlIZ21L7YM2CSpHUFJo/LQ==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-12.0.0.tgz",
+            "integrity": "sha512-v8/GY1IWQn2nOBdVtD/6e0Y6A9PRFjY86a1m5r5FUel+C7iyoQVt7gKqaAc1iRXcQkZq2DDG0aTiQptgnq51cA==",
             "dev": true,
             "dependencies": {
                 "deep-strict-equal": "^0.2.0",
                 "enhance-visitors": "^1.0.0",
                 "eslint-utils": "^2.1.0",
-                "espree": "^7.2.0",
+                "espree": "^7.3.1",
                 "espurify": "^2.0.1",
-                "import-modules": "^2.0.0",
+                "import-modules": "^2.1.0",
                 "micro-spelling-correcter": "^1.1.1",
-                "pkg-dir": "^4.2.0",
+                "pkg-dir": "^5.0.0",
                 "resolve-from": "^5.0.0"
             },
             "engines": {
                 "node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
             },
             "peerDependencies": {
-                "eslint": ">=7.7.0"
+                "eslint": ">=7.22.0"
+            }
+        },
+        "node_modules/eslint-plugin-ava/node_modules/pkg-dir": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+            "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+            "dev": true,
+            "dependencies": {
+                "find-up": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/eslint-plugin-ava/node_modules/resolve-from": {
@@ -3810,33 +3822,36 @@
             }
         },
         "node_modules/eslint-plugin-promise": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
-            "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
+            "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
             "dev": true,
             "engines": {
-                "node": ">=6"
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0"
             }
         },
         "node_modules/eslint-plugin-unicorn": {
-            "version": "28.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-28.0.2.tgz",
-            "integrity": "sha512-k4AoFP7n8/oq6lBXkdc9Flid6vw2B8j7aXFCxgzJCyKvmaKrCUFb1TFPhG9eSJQFZowqmymMPRtl8oo9NKLUbw==",
+            "version": "30.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-30.0.0.tgz",
+            "integrity": "sha512-ZKbE48Ep99z/3geLpkBfv+jNrzr2k7bLqCC/RfZOekZzAvn2/ECDE/d8zGdW1YxHmIC9pevQvm8Pl89v9GEIVw==",
             "dev": true,
             "dependencies": {
-                "ci-info": "^2.0.0",
+                "ci-info": "^3.1.1",
                 "clean-regexp": "^1.0.0",
-                "eslint-template-visitor": "^2.2.2",
+                "eslint-template-visitor": "^2.3.2",
                 "eslint-utils": "^2.1.0",
                 "eslint-visitor-keys": "^2.0.0",
                 "import-modules": "^2.1.0",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "pluralize": "^8.0.0",
                 "read-pkg-up": "^7.0.1",
-                "regexp-tree": "^0.1.22",
+                "regexp-tree": "^0.1.23",
                 "reserved-words": "^0.1.2",
                 "safe-regex": "^2.1.1",
-                "semver": "^7.3.4"
+                "semver": "^7.3.5"
             },
             "engines": {
                 "node": ">=10"
@@ -3845,8 +3860,14 @@
                 "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
             },
             "peerDependencies": {
-                "eslint": ">=7.17.0"
+                "eslint": ">=7.23.0"
             }
+        },
+        "node_modules/eslint-plugin-unicorn/node_modules/ci-info": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+            "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+            "dev": true
         },
         "node_modules/eslint-plugin-unicorn/node_modules/find-up": {
             "version": "4.1.0",
@@ -11308,30 +11329,30 @@
             }
         },
         "node_modules/xo": {
-            "version": "0.38.2",
-            "resolved": "https://registry.npmjs.org/xo/-/xo-0.38.2.tgz",
-            "integrity": "sha512-bGDGXgyPQyiVYIiqrkbFm4S1IIwlKDrNxgWnz9xWrdT4jdbfDU9fHkW6Mwab7jGms7ymoul+aRZVa3uMhcQlTw==",
+            "version": "0.39.1",
+            "resolved": "https://registry.npmjs.org/xo/-/xo-0.39.1.tgz",
+            "integrity": "sha512-7OXtjkIfCMw3XfUPGInnUhxb/w/IHqATQM7XHOxwiJqbsQ44OYcLkTZb7mA35tDtqflnvWk88wD+IxiR/XJ5gQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "^4.15.1",
-                "@typescript-eslint/parser": "^4.15.1",
+                "@typescript-eslint/eslint-plugin": "^4.22.0",
+                "@typescript-eslint/parser": "^4.22.0",
                 "arrify": "^2.0.1",
                 "cosmiconfig": "^7.0.0",
                 "debug": "^4.3.1",
-                "eslint": "^7.20.0",
-                "eslint-config-prettier": "^7.2.0",
-                "eslint-config-xo": "^0.35.0",
-                "eslint-config-xo-typescript": "^0.38.0",
+                "eslint": "^7.24.0",
+                "eslint-config-prettier": "^8.2.0",
+                "eslint-config-xo": "^0.36.0",
+                "eslint-config-xo-typescript": "^0.39.0",
                 "eslint-formatter-pretty": "^4.0.0",
                 "eslint-import-resolver-webpack": "^0.13.0",
-                "eslint-plugin-ava": "^11.0.0",
+                "eslint-plugin-ava": "^12.0.0",
                 "eslint-plugin-eslint-comments": "^3.2.0",
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-no-use-extend-native": "^0.5.0",
                 "eslint-plugin-node": "^11.1.0",
-                "eslint-plugin-prettier": "^3.3.1",
-                "eslint-plugin-promise": "^4.3.1",
-                "eslint-plugin-unicorn": "^28.0.2",
+                "eslint-plugin-prettier": "^3.4.0",
+                "eslint-plugin-promise": "^5.1.0",
+                "eslint-plugin-unicorn": "^30.0.0",
                 "find-cache-dir": "^3.3.1",
                 "find-up": "^5.0.0",
                 "fs-extra": "^9.1.0",
@@ -11339,22 +11360,22 @@
                 "globby": "^9.2.0",
                 "has-flag": "^4.0.0",
                 "imurmurhash": "^0.1.4",
-                "is-path-inside": "^3.0.2",
+                "is-path-inside": "^3.0.3",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "json5": "^2.2.0",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "meow": "^9.0.0",
-                "micromatch": "^4.0.2",
+                "micromatch": "^4.0.4",
                 "open-editor": "^3.0.0",
                 "p-reduce": "^2.1.0",
                 "path-exists": "^4.0.0",
                 "prettier": "^2.2.1",
                 "resolve-cwd": "^3.0.0",
                 "resolve-from": "^5.0.0",
-                "semver": "^7.3.4",
+                "semver": "^7.3.5",
                 "slash": "^3.0.0",
                 "to-absolute-glob": "^2.0.2",
-                "typescript": "^4.1.5",
+                "typescript": "^4.2.4",
                 "update-notifier": "^5.1.0"
             },
             "bin": {
@@ -14323,25 +14344,25 @@
             }
         },
         "eslint-config-prettier": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
-            "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+            "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
             "dev": true,
             "requires": {}
         },
         "eslint-config-xo": {
-            "version": "0.35.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.35.0.tgz",
-            "integrity": "sha512-+WyZTLWUJlvExFrBU/Ldw8AB/S0d3x+26JQdBWbcqig2ZaWh0zinYcHok+ET4IoPaEcRRf3FE9kjItNVjBwnAg==",
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.36.0.tgz",
+            "integrity": "sha512-RCaqCyI38awe3qgiO0Z8CqHs9yw7dMKdV6ZRTFSR7lm0//370tbDEZaQBXnztgpwe5m6D+VvFWc3vLMP/W6EAg==",
             "dev": true,
             "requires": {
                 "confusing-browser-globals": "1.0.10"
             }
         },
         "eslint-config-xo-typescript": {
-            "version": "0.38.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.38.0.tgz",
-            "integrity": "sha512-f5z0gN1r9X84PK1qav6T6YT1zW6KcAqtsMPtmqoKBLt4ACRr6tbAddtFwqkluAEH9JvHjWxuB8vu4KJFcjuzdQ==",
+            "version": "0.39.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.39.0.tgz",
+            "integrity": "sha512-UP4WqkmAKerYAhJTLdfrjBhD/nM1ePEugQNBJjzFfZv/lJ4yQjTzDBjfjsgluX1kz9PajRMaaipiWloJEODdGg==",
             "dev": true,
             "requires": {}
         },
@@ -14492,22 +14513,31 @@
             }
         },
         "eslint-plugin-ava": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-11.0.0.tgz",
-            "integrity": "sha512-UMGedfl/gIKx1tzjGtAsTSJgowyAEZU2VWmpoWXYcuuV4B2H4Cu90yuMgMPEVt1mQlIZ21L7YM2CSpHUFJo/LQ==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-12.0.0.tgz",
+            "integrity": "sha512-v8/GY1IWQn2nOBdVtD/6e0Y6A9PRFjY86a1m5r5FUel+C7iyoQVt7gKqaAc1iRXcQkZq2DDG0aTiQptgnq51cA==",
             "dev": true,
             "requires": {
                 "deep-strict-equal": "^0.2.0",
                 "enhance-visitors": "^1.0.0",
                 "eslint-utils": "^2.1.0",
-                "espree": "^7.2.0",
+                "espree": "^7.3.1",
                 "espurify": "^2.0.1",
-                "import-modules": "^2.0.0",
+                "import-modules": "^2.1.0",
                 "micro-spelling-correcter": "^1.1.1",
-                "pkg-dir": "^4.2.0",
+                "pkg-dir": "^5.0.0",
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
+                "pkg-dir": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+                    "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^5.0.0"
+                    }
+                },
                 "resolve-from": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -14677,32 +14707,39 @@
             }
         },
         "eslint-plugin-promise": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
-            "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
-            "dev": true
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
+            "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-unicorn": {
-            "version": "28.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-28.0.2.tgz",
-            "integrity": "sha512-k4AoFP7n8/oq6lBXkdc9Flid6vw2B8j7aXFCxgzJCyKvmaKrCUFb1TFPhG9eSJQFZowqmymMPRtl8oo9NKLUbw==",
+            "version": "30.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-30.0.0.tgz",
+            "integrity": "sha512-ZKbE48Ep99z/3geLpkBfv+jNrzr2k7bLqCC/RfZOekZzAvn2/ECDE/d8zGdW1YxHmIC9pevQvm8Pl89v9GEIVw==",
             "dev": true,
             "requires": {
-                "ci-info": "^2.0.0",
+                "ci-info": "^3.1.1",
                 "clean-regexp": "^1.0.0",
-                "eslint-template-visitor": "^2.2.2",
+                "eslint-template-visitor": "^2.3.2",
                 "eslint-utils": "^2.1.0",
                 "eslint-visitor-keys": "^2.0.0",
                 "import-modules": "^2.1.0",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "pluralize": "^8.0.0",
                 "read-pkg-up": "^7.0.1",
-                "regexp-tree": "^0.1.22",
+                "regexp-tree": "^0.1.23",
                 "reserved-words": "^0.1.2",
                 "safe-regex": "^2.1.1",
-                "semver": "^7.3.4"
+                "semver": "^7.3.5"
             },
             "dependencies": {
+                "ci-info": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+                    "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+                    "dev": true
+                },
                 "find-up": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -20421,30 +20458,30 @@
             "dev": true
         },
         "xo": {
-            "version": "0.38.2",
-            "resolved": "https://registry.npmjs.org/xo/-/xo-0.38.2.tgz",
-            "integrity": "sha512-bGDGXgyPQyiVYIiqrkbFm4S1IIwlKDrNxgWnz9xWrdT4jdbfDU9fHkW6Mwab7jGms7ymoul+aRZVa3uMhcQlTw==",
+            "version": "0.39.1",
+            "resolved": "https://registry.npmjs.org/xo/-/xo-0.39.1.tgz",
+            "integrity": "sha512-7OXtjkIfCMw3XfUPGInnUhxb/w/IHqATQM7XHOxwiJqbsQ44OYcLkTZb7mA35tDtqflnvWk88wD+IxiR/XJ5gQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/eslint-plugin": "^4.15.1",
-                "@typescript-eslint/parser": "^4.15.1",
+                "@typescript-eslint/eslint-plugin": "^4.22.0",
+                "@typescript-eslint/parser": "^4.22.0",
                 "arrify": "^2.0.1",
                 "cosmiconfig": "^7.0.0",
                 "debug": "^4.3.1",
-                "eslint": "^7.20.0",
-                "eslint-config-prettier": "^7.2.0",
-                "eslint-config-xo": "^0.35.0",
-                "eslint-config-xo-typescript": "^0.38.0",
+                "eslint": "^7.24.0",
+                "eslint-config-prettier": "^8.2.0",
+                "eslint-config-xo": "^0.36.0",
+                "eslint-config-xo-typescript": "^0.39.0",
                 "eslint-formatter-pretty": "^4.0.0",
                 "eslint-import-resolver-webpack": "^0.13.0",
-                "eslint-plugin-ava": "^11.0.0",
+                "eslint-plugin-ava": "^12.0.0",
                 "eslint-plugin-eslint-comments": "^3.2.0",
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-no-use-extend-native": "^0.5.0",
                 "eslint-plugin-node": "^11.1.0",
-                "eslint-plugin-prettier": "^3.3.1",
-                "eslint-plugin-promise": "^4.3.1",
-                "eslint-plugin-unicorn": "^28.0.2",
+                "eslint-plugin-prettier": "^3.4.0",
+                "eslint-plugin-promise": "^5.1.0",
+                "eslint-plugin-unicorn": "^30.0.0",
                 "find-cache-dir": "^3.3.1",
                 "find-up": "^5.0.0",
                 "fs-extra": "^9.1.0",
@@ -20452,22 +20489,22 @@
                 "globby": "^9.2.0",
                 "has-flag": "^4.0.0",
                 "imurmurhash": "^0.1.4",
-                "is-path-inside": "^3.0.2",
+                "is-path-inside": "^3.0.3",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "json5": "^2.2.0",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "meow": "^9.0.0",
-                "micromatch": "^4.0.2",
+                "micromatch": "^4.0.4",
                 "open-editor": "^3.0.0",
                 "p-reduce": "^2.1.0",
                 "path-exists": "^4.0.0",
                 "prettier": "^2.2.1",
                 "resolve-cwd": "^3.0.0",
                 "resolve-from": "^5.0.0",
-                "semver": "^7.3.4",
+                "semver": "^7.3.5",
                 "slash": "^3.0.0",
                 "to-absolute-glob": "^2.0.2",
-                "typescript": "^4.1.5",
+                "typescript": "^4.2.4",
                 "update-notifier": "^5.1.0"
             },
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "pug-lint": "^2.6.0",
         "pug-lint-config-clock": "^2.0.0",
         "request": "^2.88.2",
-        "xo": "^0.38.2"
+        "xo": "^0.39.1"
     },
     "engines": {
         "node": "14.x"
@@ -143,7 +143,10 @@
                 "strict": true,
                 "rules": {
                     "unicorn/no-abusive-eslint-disable": "off",
-                    "unicorn/prefer-number-properties": "off"
+                    "unicorn/prefer-number-properties": "off",
+                    "no-var": "off",
+                    "prefer-arrow-callback": "off",
+                    "object-shorthand": "off"
                 }
             },
             {


### PR DESCRIPTION
Update `xo` code style linter dependency and fix rules for the files that are supposed to be run in the browser.
Browser unsafe rules are disabled for those files.