### PR TITLE
Fix typo on the front page (index.pug)

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -3,7 +3,7 @@ extends layout.pug
 block content
     h2.second-heading.mb-3 Quick Start
 
-    p.sub-heading Get your production ready CDN links bellow. You can also automate your upgrades by pulling the latest versions from our API.
+    p.sub-heading Get your production ready CDN links below. You can also automate your upgrades by pulling the latest versions from our API.
     -var current = config.files.bootstrap.find(file => file.current);
     -var previous = config.files.bootstrap.find(file => semver.satisfies(file.version, '^4', { includePrerelease: true }));
 


### PR DESCRIPTION
"below" was spelt "bellow".